### PR TITLE
add timestamp to oci artifact manifest

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -58350,6 +58350,10 @@ class OCIImage {
     }
     async addArtifact(opts) {
         let artifactDescriptor;
+        const annotations = {
+            'org.opencontainers.image.created': new Date().toISOString(),
+            ...opts.annotations
+        };
         try {
             if (this.#credentials) {
                 await this.#client.signIn(this.#credentials);
@@ -58368,7 +58372,7 @@ class OCIImage {
                     ...emptyBlob,
                     mediaType: constants_1.CONTENT_TYPE_EMPTY_DESCRIPTOR
                 },
-                annotations: opts.annotations
+                annotations
             });
             /* istanbul ignore if */
             if (this.#downgrade) {
@@ -58385,7 +58389,7 @@ class OCIImage {
                     artifact: {
                         ...artifactDescriptor,
                         artifactType: opts.mediaType,
-                        annotations: opts.annotations
+                        annotations
                     },
                     imageDigest: opts.imageDigest
                 });

--- a/src/oci/image.ts
+++ b/src/oci/image.ts
@@ -39,6 +39,11 @@ export class OCIImage {
   async addArtifact(opts: AddArtifactOptions): Promise<Descriptor> {
     let artifactDescriptor: UploadManifestResponse
 
+    const annotations = {
+      'org.opencontainers.image.created': new Date().toISOString(),
+      ...opts.annotations
+    }
+
     try {
       if (this.#credentials) {
         await this.#client.signIn(this.#credentials)
@@ -63,7 +68,7 @@ export class OCIImage {
           ...emptyBlob,
           mediaType: CONTENT_TYPE_EMPTY_DESCRIPTOR
         },
-        annotations: opts.annotations
+        annotations
       })
 
       /* istanbul ignore if */
@@ -85,7 +90,7 @@ export class OCIImage {
           artifact: {
             ...artifactDescriptor,
             artifactType: opts.mediaType,
-            annotations: opts.annotations
+            annotations
           },
           imageDigest: opts.imageDigest
         })


### PR DESCRIPTION
When uploading a Sigstore bundle to an OCI registry, this change adds an annotation to the artifact manifest which captures the time the annotation was added. When a container image has multiple referring artifacts, the presence of a timestamp may help users to differentiate between them.

The artifact manifest will look something like:

```json
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.manifest.v1+json",
  "artifactType": "application/vnd.dev.sigstore.bundle+json",
  "config": {
    "mediaType": "application/vnd.oci.empty.v1+json",
    "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
    "size": 2
  },
  "layers": [
    {
      "mediaType": "application/vnd.dev.sigstore.bundle+json",
      "digest": "sha256:1dcb0e0f5724f447db8e555ea7a559ee500e37eca03066625336663c97ca6202",
      "size": 4971
    }
  ],
  "subject": {
    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
    "digest": "sha256:59fafc928fa605f505bbab16dd2c4bd4a546ec6987a65e37bae3a39f6655e822",
    "size": 523
  },
  "annotations": {
    "dev.sigstore.bundle/predicateType": "https://slsa.dev/provenance/v1",
    "org.opencontainers.image.created": "2023-11-14T21:48:57Z"
  }
}
```

Note that the "org.opencontainers.image.created" annotation key is one of the predefined keys described in the [OCI Image spec](https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys) (and is intended to be used to denote the "created-at" value for any artifact, not just images).