### PR TITLE
integration test for signing w/ GH Sigstore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
       - name: Test Local Action
         id: test-action
         env:
-          INPUT_PRIVATE: 'true'
+          INPUT_PRIVATE-SIGNING: 'true'
         uses: ./
         with:
           subject-digest: 'sha256:7d070f6b64d9bcc530fe99cc21eaaa4b3c364e0b2d367d7735671fa202a03b32'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,3 +118,24 @@ jobs:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
+
+  test-action-private:
+    name: GitHub Actions Test (Private)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Test Local Action
+        id: test-action
+        env:
+          INPUT_PRIVATE: 'true'
+        uses: ./
+        with:
+          subject-digest: 'sha256:7d070f6b64d9bcc530fe99cc21eaaa4b3c364e0b2d367d7735671fa202a03b32'
+          subject-name: 'subject'

--- a/dist/index.js
+++ b/dist/index.js
@@ -58160,8 +58160,10 @@ const COLOR_DEFAULT = '\x1B[39m';
  */
 async function run() {
     // Provenance visibility will be public ONLY if we can confirm that the
-    // repository is public. Otherwise, it will be private.
-    const visibility = github.context.payload.repository?.visibility === 'public'
+    // repository is public AND the undocumented "private" arg is NOT set.
+    // Otherwise, it will be private.
+    const visibility = github.context.payload.repository?.visibility === 'public' &&
+        core.getInput('private') !== 'true'
         ? 'public'
         : 'private';
     core.debug(`Provenance attestation visibility: ${visibility}`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -58160,10 +58160,10 @@ const COLOR_DEFAULT = '\x1B[39m';
  */
 async function run() {
     // Provenance visibility will be public ONLY if we can confirm that the
-    // repository is public AND the undocumented "private" arg is NOT set.
+    // repository is public AND the undocumented "private-signing" arg is NOT set.
     // Otherwise, it will be private.
     const visibility = github.context.payload.repository?.visibility === 'public' &&
-        core.getInput('private') !== 'true'
+        core.getInput('private-signing') !== 'true'
         ? 'public'
         : 'private';
     core.debug(`Provenance attestation visibility: ${visibility}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,9 +16,11 @@ const COLOR_DEFAULT = '\x1B[39m'
  */
 export async function run(): Promise<void> {
   // Provenance visibility will be public ONLY if we can confirm that the
-  // repository is public. Otherwise, it will be private.
+  // repository is public AND the undocumented "private" arg is NOT set.
+  // Otherwise, it will be private.
   const visibility =
-    github.context.payload.repository?.visibility === 'public'
+    github.context.payload.repository?.visibility === 'public' &&
+    core.getInput('private') !== 'true'
       ? 'public'
       : 'private'
   core.debug(`Provenance attestation visibility: ${visibility}`)

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,11 +16,11 @@ const COLOR_DEFAULT = '\x1B[39m'
  */
 export async function run(): Promise<void> {
   // Provenance visibility will be public ONLY if we can confirm that the
-  // repository is public AND the undocumented "private" arg is NOT set.
+  // repository is public AND the undocumented "private-signing" arg is NOT set.
   // Otherwise, it will be private.
   const visibility =
     github.context.payload.repository?.visibility === 'public' &&
-    core.getInput('private') !== 'true'
+    core.getInput('private-signing') !== 'true'
       ? 'public'
       : 'private'
   core.debug(`Provenance attestation visibility: ${visibility}`)


### PR DESCRIPTION
Sets-up an integration test which uses the Github Sigstore instance to sign the provenance statement.

Typically, the Sigstore instance is selected automatically based on the visibility of the repo which initiates the workflow. Given that this repo is public, I introduced an undocumented input argument which can be used to force the selection of the private Sigstore instance.