### PR TITLE
foundation for multi-subject support

### DIFF
--- a/__tests__/subject.test.ts
+++ b/__tests__/subject.test.ts
@@ -101,8 +101,9 @@ describe('subjectFromInputs', () => {
         const subject = await subjectFromInputs()
 
         expect(subject).toBeDefined()
-        expect(subject.name).toEqual(name)
-        expect(subject.digest).toEqual({ [alg]: digest })
+        expect(subject).toHaveLength(1)
+        expect(subject[0].name).toEqual(name)
+        expect(subject[0].digest).toEqual({ [alg]: digest })
       })
     })
   })
@@ -154,8 +155,9 @@ describe('subjectFromInputs', () => {
         const subject = await subjectFromInputs()
 
         expect(subject).toBeDefined()
-        expect(subject.name).toEqual(filename)
-        expect(subject.digest).toEqual({ sha256: expectedDigest })
+        expect(subject).toHaveLength(1)
+        expect(subject[0].name).toEqual(filename)
+        expect(subject[0].digest).toEqual({ sha256: expectedDigest })
       })
     })
 
@@ -170,8 +172,9 @@ describe('subjectFromInputs', () => {
         const subject = await subjectFromInputs()
 
         expect(subject).toBeDefined()
-        expect(subject.name).toEqual(name)
-        expect(subject.digest).toEqual({ sha256: expectedDigest })
+        expect(subject).toHaveLength(1)
+        expect(subject[0].name).toEqual(name)
+        expect(subject[0].digest).toEqual({ sha256: expectedDigest })
       })
     })
   })

--- a/src/sign.ts
+++ b/src/sign.ts
@@ -30,9 +30,9 @@ type SignOptions = {
   tsaServerURL?: string
 }
 
-type Visibility = 'public' | 'private'
+export type Visibility = 'public' | 'private'
 
-type Attestation = {
+export type Attestation = {
   bundle: unknown
   certificate: string
   tlogURL?: string

--- a/src/subject.ts
+++ b/src/subject.ts
@@ -14,7 +14,7 @@ export type Subject = {
 // specified as a path to a file or as a digest. If a path is provided, the
 // file's digest is calculated and returned along with the subject's name. If a
 // digest is provided, the name must also be provided.
-export const subjectFromInputs = async (): Promise<Subject> => {
+export const subjectFromInputs = async (): Promise<Subject[]> => {
   const subjectPath = core.getInput('subject-path', { required: false })
   const subjectDigest = core.getInput('subject-digest', { required: false })
   const subjectName = core.getInput('subject-name', { required: false })
@@ -34,9 +34,9 @@ export const subjectFromInputs = async (): Promise<Subject> => {
   }
 
   if (subjectPath) {
-    return getSubjectFromPath(subjectPath, subjectName)
+    return [await getSubjectFromPath(subjectPath, subjectName)]
   } else {
-    return getSubjectFromDigest(subjectDigest, subjectName)
+    return [getSubjectFromDigest(subjectDigest, subjectName)]
   }
 }
 


### PR DESCRIPTION
Lays the groundwork for being able to attest multiple artifacts with a single invocation of the action. Note that this DOES NOT add globbing support, but simply rejiggers the main function so that it can iterate over a list of subjects and generate an attestation for each. 

Support for accepting glob patterns for artifact inputs will be added in a follow-up PR. 