### PR TITLE
fixes for pushing attestations to ECR

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -62444,6 +62444,13 @@ class OCIImage {
             if (this.#downgrade) {
                 delete manifest.subject;
                 delete manifest.artifactType;
+                // ECR can't handle media types with parameters, so we need to strip the
+                // version parameter from the Sigstore bundle media type.
+                manifest.layers[0].mediaType = manifest.layers[0].mediaType.replace(/;.*/, '');
+                // ECR can't handle the "application/vnd.oci.empty.v1+json" media type
+                // for the config blob defined in OCI 1.1, so we need to use the Docker
+                // V2 API media type
+                manifest.config.mediaType = 'application/vnd.oci.image.config.v1+json';
             }
             // Upload artifact manifest
             artifactDescriptor = await this.#client.uploadManifest(JSON.stringify(manifest));

--- a/src/oci/image.ts
+++ b/src/oci/image.ts
@@ -75,6 +75,18 @@ export class OCIImage {
       if (this.#downgrade) {
         delete manifest.subject
         delete manifest.artifactType
+
+        // ECR can't handle media types with parameters, so we need to strip the
+        // version parameter from the Sigstore bundle media type.
+        manifest.layers[0].mediaType = manifest.layers[0].mediaType.replace(
+          /;.*/,
+          ''
+        )
+
+        // ECR can't handle the "application/vnd.oci.empty.v1+json" media type
+        // for the config blob defined in OCI 1.1, so we need to use the Docker
+        // V2 API media type
+        manifest.config.mediaType = 'application/vnd.oci.image.config.v1+json'
       }
 
       // Upload artifact manifest


### PR DESCRIPTION
Does some munging of the artifact manifest in order to get something which will be accepted by AWS ECR.

A normal OCI 1.1. artifact manifest would look something like this:

```json
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.manifest.v1+json",
  "artifactType": "application/vnd.dev.sigstore.bundle+json;version=0.2",
  "config": {
    "mediaType": "application/vnd.oci.empty.v1+json",
    "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
    "size": 2
  },
  "layers": [
    {
      "mediaType": "application/vnd.dev.sigstore.bundle+json;version=0.2",
      "digest": "sha256:674d7a2aa463e176a039b219067cae2d8ad968956da754ae71a45d30b3f537d3",
      "size": 4967
    }
  ],
  "subject": {
    "mediaType": "application/vnd.oci.image.index.v1+json",
    "digest": "sha256:98e2695c26afcbd13271cb767dd728f02e91ea3528a4e29944784e9ad1e17df5",
    "size": 855
  },
  "annotations": {
    "org.opencontainers.image.created": "2024-01-19T22:42:37.456Z",
    "dev.sigstore.bundle/predicateType": "https://slsa.dev/provenance/v1"
  }
}
```

The manifest which we'll use for AWS ECR will look like this:

```json
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.manifest.v1+json",
  "config": {
    "mediaType": "application/vnd.oci.image.config.v1+json",
    "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
    "size": 2
  },
  "layers": [
    {
      "mediaType": "application/vnd.dev.sigstore.bundle+json",
      "digest": "sha256:4548883ed3f77fed7f19993243c9a111802ad55a3aa66983ee75d1b12a56ab30",
      "size": 5007
    }
  ],
  "annotations": {
    "org.opencontainers.image.created": "2024-01-19T22:42:35.116Z",
    "dev.sigstore.bundle/predicateType": "https://slsa.dev/provenance/v1"
  }
}
```

The key differences are as follows:

1. The `subject` field has been removed. This field points to the image manifest that this artifact refers to (the subject of our attestation in this case). This is nice information to have here, but is not critical as the subject will have to have been known already in order to even retrieve this manifest.
2. The top-level `artifactType` field has been removed. Technically a part of the OCI 1.1 spec for referring artifacts, but not strictly needed in order to find the artifact associated with an image. In this case, the value is redundant with the `mediaType` identified in the layer
3. The `mediaType` used to identify the Sigstore bundle has been truncated. AWS ECR will not accept a media type containing a parameter so the `;version=0.2` portion of the bundle media type has to be stripped out. On the retrieval side, we may need to use some fuzzy matching to properly identify the specific layer containing the Sigstore bundle since the `mediaType` string won't match EXACTLY our expected content type.
4. The `mediaType` for the `config` block has been changed from `application/vnd.oci.empty.v1+json` to `application/vnd.oci.image.config.v1+json`. The OCI 1.1 guidance when your artifact does NOT require config data is to use the "empty" media type, but AWS ECR will not accept this. Changing it to a value which IS recognized by ECR allows us bypass the issue and should have no impact on our ability to lookup this manifest given that we don't care about the config object to begin with.

These changes give us something which will be accepted by AWS ECR while still hewing pretty closely to the OCI [guidelines for artifact usage](https://github.com/opencontainers/image-spec/blob/main/manifest.md#guidelines-for-artifact-usage).

As ECR adds better OCI 1.1 support in the future we should be able to easily back out this hacks.