### PR TITLE
serialize attestations for globbed artifacts

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -62227,7 +62227,10 @@ async function run() {
         // Calculate subject from inputs and generate provenance
         const subjects = await (0, subject_1.subjectFromInputs)();
         // Generate attestations for each subject serially
-        const attestations = await Promise.all(subjects.map(async (subject) => await attest(subject, visibility)));
+        const attestations = [];
+        for (const subject of subjects) {
+            attestations.push(await attest(subject, visibility));
+        }
         // Set bundle as action output, but ONLY IF there is a single attestation
         if (attestations.length === 1) {
             core.setOutput('bundle', attestations[0].bundle);

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,9 +30,10 @@ export async function run(): Promise<void> {
     const subjects = await subjectFromInputs()
 
     // Generate attestations for each subject serially
-    const attestations = await Promise.all(
-      subjects.map(async subject => await attest(subject, visibility))
-    )
+    const attestations: Attestation[] = []
+    for (const subject of subjects) {
+      attestations.push(await attest(subject, visibility))
+    }
 
     // Set bundle as action output, but ONLY IF there is a single attestation
     if (attestations.length === 1) {


### PR DESCRIPTION
Despite what the comment says in the code, we're attempting to generate attestations for globbed artifacts in parallel. As the artifact count increases, this becomes sorta dangerous. Better off to process these serially.

We can revisit this in the future and maybe batch process a handful of artifacts in parallel.