### PR TITLE
support ACR auth via identity token

### DIFF
--- a/__tests__/oci/credentials.test.ts
+++ b/__tests__/oci/credentials.test.ts
@@ -92,10 +92,38 @@ describe('getRegistryCredentials', () => {
       )
     })
 
-    it('throws an error', () => {
+    it('returns the credentials', () => {
       const creds = getRegistryCredentials(registryName)
 
       expect(creds).toEqual({ username, password })
+    })
+  })
+
+  describe('when credentials specify an identity token', () => {
+    const username = 'username'
+    const password = 'password'
+    const token = 'identitytoken'
+    const dockerConfig = {
+      auths: {
+        [registryName]: {
+          auth: Buffer.from(`${username}:${password}`).toString('base64'),
+          identitytoken: token
+        }
+      }
+    }
+
+    beforeEach(() => {
+      fs.writeFileSync(
+        path.join(tempDir, '.docker', 'config.json'),
+        JSON.stringify(dockerConfig),
+        {}
+      )
+    })
+
+    it('returns the credentials', () => {
+      const creds = getRegistryCredentials(registryName)
+
+      expect(creds).toEqual({ username, password: token })
     })
   })
 
@@ -118,7 +146,7 @@ describe('getRegistryCredentials', () => {
       )
     })
 
-    it('throws an error', () => {
+    it('returns the credentials', () => {
       const creds = getRegistryCredentials(registryName)
 
       expect(creds).toEqual({ username, password })

--- a/dist/index.js
+++ b/dist/index.js
@@ -62343,7 +62343,11 @@ const getRegistryCredentials = (registry) => {
     if (!creds) {
         throw new Error(`No credentials found for registry ${registry}`);
     }
-    return (0, exports.fromBasicAuth)(creds.auth);
+    // Extract username/password from auth string
+    const { username, password } = (0, exports.fromBasicAuth)(creds.auth);
+    // If the identitytoken is present, use it as the password (primarily for ACR)
+    const pass = creds.identitytoken ? creds.identitytoken : password;
+    return { username, password: pass };
 };
 exports.getRegistryCredentials = getRegistryCredentials;
 // Encode the username and password as base64-encoded basicauth value

--- a/src/oci/credentials.ts
+++ b/src/oci/credentials.ts
@@ -8,7 +8,7 @@ export type Credentials = {
 }
 
 type DockerConifg = {
-  auths?: { [registry: string]: { auth: string } }
+  auths?: { [registry: string]: { auth: string; identitytoken?: string } }
 }
 
 // Returns the credentials for a given registry by reading the Docker config
@@ -35,7 +35,13 @@ export const getRegistryCredentials = (registry: string): Credentials => {
     throw new Error(`No credentials found for registry ${registry}`)
   }
 
-  return fromBasicAuth(creds.auth)
+  // Extract username/password from auth string
+  const { username, password } = fromBasicAuth(creds.auth)
+
+  // If the identitytoken is present, use it as the password (primarily for ACR)
+  const pass = creds.identitytoken ? creds.identitytoken : password
+
+  return { username, password: pass }
 }
 
 // Encode the username and password as base64-encoded basicauth value


### PR DESCRIPTION
Fixes https://github.com/github-early-access/generate-build-provenance/issues/114

Updates the `getRegistryCredentials` function to properly handle an `identitytoken` value if it is present. This value is used when authenticating with Azure Container Registry via workload identity federation.