### PR TITLE
remove unneeded packages:write perms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,8 @@ jobs:
     name: GitHub Actions Test (Linux)
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       id-token: write
-      packages: write
 
     steps:
       - name: Checkout
@@ -65,9 +64,8 @@ jobs:
     name: GitHub Actions Test (Windows)
     runs-on: windows-latest
     permissions:
-      contents: read
+      contents: write
       id-token: write
-      packages: write
 
     steps:
       - name: Checkout
@@ -83,7 +81,7 @@ jobs:
     name: GitHub Actions Test (OCI)
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       id-token: write
       packages: write
     env:
@@ -125,9 +123,8 @@ jobs:
     name: GitHub Actions Test (Private)
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       id-token: write
-      packages: write
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -14,12 +14,11 @@ attest,
    permissions:
      id-token: write
      contents: write
-     packages: write
    ```
 
    The `id-token` permission gives the action the ability to mint the OIDC token
-   necessary to request a Sigstore signing certificate. The `contents` and
-   `packages` permissions are necessary to persist the attestation.
+   necessary to request a Sigstore signing certificate. The `contents`
+   permission is necessary to persist the attestation.
 
    > **NOTE**: The set of required permissions will be refined in a future
    > release.
@@ -168,7 +167,6 @@ jobs:
   build:
     permissions:
       id-token: write
-      packages: write
       contents: write
 
     steps:
@@ -197,7 +195,6 @@ jobs:
   build:
     permissions:
       id-token: write
-      packages: write
       contents: write
 
     steps:


### PR DESCRIPTION
Remove references to the `packages: write` permission in the documentation. This permission is no longer necessary to write attestations to the GH API.

Note, that this permission still appears in a few places where we happen to also push a container image to GHCR.