### PR TITLE
friendly error when id-token: write missing

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -80,6 +80,32 @@ describe('action', () => {
     setGHContext(originalContext)
   })
 
+  describe('when ACTIONS_ID_TOKEN_REQUEST_URL is not set', () => {
+    const inputs = {
+      'subject-digest':
+        'sha256:7d070f6b64d9bcc530fe99cc21eaaa4b3c364e0b2d367d7735671fa202a03b32',
+      'subject-name': 'subject',
+      'github-token': 'gh-token'
+    }
+
+    beforeEach(() => {
+      // Nullify the OIDC token URL
+      process.env.ACTIONS_ID_TOKEN_REQUEST_URL = ''
+
+      getInputMock.mockImplementation(mockInput(inputs))
+      getBooleanInputMock.mockImplementation(() => false)
+    })
+
+    it('sets a failed status', async () => {
+      await main.run()
+
+      expect(runMock).toHaveReturned()
+      expect(setFailedMock).toHaveBeenCalledWith(
+        expect.stringMatching(/missing "id-token" permission/)
+      )
+    })
+  })
+
   describe('when the repository is private', () => {
     const inputs = {
       'subject-digest':

--- a/dist/index.js
+++ b/dist/index.js
@@ -62224,6 +62224,9 @@ async function run() {
         : 'private';
     core.debug(`Provenance attestation visibility: ${visibility}`);
     try {
+        if (!process.env.ACTIONS_ID_TOKEN_REQUEST_URL) {
+            throw new Error('missing "id-token" permission. Please add "permissions: id-token: write" to your workflow.');
+        }
         // Calculate subject from inputs and generate provenance
         const subjects = await (0, subject_1.subjectFromInputs)();
         // Generate attestations for each subject serially

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,12 @@ export async function run(): Promise<void> {
   core.debug(`Provenance attestation visibility: ${visibility}`)
 
   try {
+    if (!process.env.ACTIONS_ID_TOKEN_REQUEST_URL) {
+      throw new Error(
+        'missing "id-token" permission. Please add "permissions: id-token: write" to your workflow.'
+      )
+    }
+
     // Calculate subject from inputs and generate provenance
     const subjects = await subjectFromInputs()
 


### PR DESCRIPTION
Better error messaging when the calling workflow is missing the `id-token: write` permission.

Previously, the user would see something like:

```
Error: error retrieving identity token
```

Which doesn't help the user to know what they should do to fix the issue.

This change adds an explicit check to see if the correct permissions have been set and will present an error message instructing the user how to fix the issue:

<img width="822" alt="image" src="https://github.com/github-early-access/generate-build-provenance/assets/398027/1f399f24-c49a-42f5-8510-ba92ca81f68a">
