### PR TITLE
remove dockerhub from OCI downgrade list

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,9 +14,8 @@ jobs:
     name: Publish/Verify (Container Image)
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       id-token: write
-      packages: write
     services:
       registry:
         image: registry@sha256:860f379a011eddfab604d9acfe3cf50b2d6e958026fb0f977132b0b083b1a3d7 # 2.8.3

--- a/dist/index.js
+++ b/dist/index.js
@@ -62654,9 +62654,7 @@ class OCIImage {
         this.#client = new registry_1.RegistryClient(image.registry, image.path, opts);
         this.#credentials = creds;
         // If the registry is not OCI-compliant, downgrade to Docker V2 API
-        this.#downgrade =
-            image.registry.includes('docker.io') ||
-                image.registry.includes('amazonaws.com');
+        this.#downgrade = image.registry.includes('amazonaws.com');
     }
     async addArtifact(opts) {
         let artifactDescriptor;

--- a/src/oci/image.ts
+++ b/src/oci/image.ts
@@ -31,9 +31,7 @@ export class OCIImage {
     this.#credentials = creds
 
     // If the registry is not OCI-compliant, downgrade to Docker V2 API
-    this.#downgrade =
-      image.registry.includes('docker.io') ||
-      image.registry.includes('amazonaws.com')
+    this.#downgrade = image.registry.includes('amazonaws.com')
   }
 
   async addArtifact(opts: AddArtifactOptions): Promise<Descriptor> {


### PR DESCRIPTION
Recent re-testing against the Docker Hub registry shows that it now supports OCI 1.1 compliant artifact management.

This change removes Docker Hub from the list of registries that would trigger a downgrade of the artifact manifest published when uploading an attestation bundle.