### PR TITLE
remove gh-attestation install line

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -52,5 +52,4 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh ext install github-early-access/gh-attestation
           gh attestation verify oci://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} -R ${{ github.repository }}


### PR DESCRIPTION
In the e2e workflow, removes the step which installs the `gh-attestation` extension for the gh CLI (it's not bundled into the CLI by default)

<img width="526" alt="image" src="https://github.com/github-early-access/generate-build-provenance/assets/398027/55ae888f-5d32-48f2-a53b-817cc57004d2">
