### PR TITLE
add deprecation warning to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,24 @@
 GitHub Action to create, sign and upload a build provenance attestation for
 artifacts built as part of a workflow.
 
+**NOTE:** This action has been deprecated in favor of
+[`actions/attest-build-provenance`](https://github.com/actions/attest-build-provenance).
+All users are encouraged to move to the new action -- this repository will not
+receive further updates and may be removed at some point.
+
+The inputs to the `attest-build-provenance` action are identical to
+`generate-build-provenance`, so migrating to the new version is as simple as
+updating the `uses:` value in your workflows to reference the new name:
+
+```
+github-early-access/generate-build-provenance@main
+```
+becomes
+```
+actions/attest-build-provenance@v1
+```
+
+
 ## Usage
 
 Within the GitHub Actions workflow which builds some artifact you would like to

--- a/README.md
+++ b/README.md
@@ -12,14 +12,19 @@ The inputs to the `attest-build-provenance` action are identical to
 `generate-build-provenance`, so migrating to the new version is as simple as
 updating the `uses:` value in your workflows to reference the new name:
 
-```
+```text
 github-early-access/generate-build-provenance@main
 ```
+
 becomes
-```
+
+```text
 actions/attest-build-provenance@v1
 ```
 
+Attestations generated with the new action use a newer version of the Sigstore
+[bundle format][5] (v0.3.1 vs v0.2.1) and require version [2.49.0][7] or later
+of the `gh` CLI to verify.
 
 ## Usage
 
@@ -305,3 +310,4 @@ jobs:
 [5]:
   https://github.com/sigstore/protobuf-specs/blob/main/protos/sigstore_bundle.proto
 [6]: https://github.com/actions/toolkit/tree/main/packages/glob#patterns
+[7]: https://github.com/cli/cli/releases/tag/v2.49.0


### PR DESCRIPTION
Update README with text explaining that users should move to the new `actions/attest-build-provenance` action.